### PR TITLE
updated metadata with flags etc for rna-seq, cnv workflow, protect

### DIFF
--- a/schemas/metadata_schema.json
+++ b/schemas/metadata_schema.json
@@ -34,7 +34,8 @@
             "properties": {
                 "analysis_type": {
                     "description": "The analysis type needs to be tightly controlled because it is used in the metadata merging script to assign flags.",
-                    "enum": ["sequence_upload", "alignment", "rna_seq_quantification", "germline_variant_calling", "somatic_variant_calling", "immuno_target_pipelines"]
+                    "enum": ["sequence_upload", "alignment", "rna_seq_quantification", "germline_variant_calling", "somatic_variant_calling", "immuno_target_pipelines", "cnv_variant_calling", "protect_immunology"]
+
                 },
                 "parent_uuids": {
                     "description": "parent UUIDs for this workflow",
@@ -89,8 +90,8 @@
                 }, {
                     "pattern": "^Metastatic tumour -"
                 }, {
-            "pattern": "^Cell line -"
-        }
+                    "pattern": "^Cell line -"
+                }
             ]
         }
     },
@@ -165,7 +166,7 @@
         "missing_items": {
             "description": "record parent_uuids of missing items",
             "type": "object",
-            "required": ["normal_sequence", "tumor_sequence", "normal_alignment", "tumor_alignment" , "normal_germline_variants" , "tumor_somatic_variants", "normal_rnaseq_variants" , "tumor_rnaseq_variants"],
+            "required": ["normal_sequence", "tumor_sequence", "normal_alignment", "tumor_alignment", "normal_germline_variants", "tumor_somatic_variants", "normal_rnaseq_variants", "tumor_rnaseq_variants", "normal_rna_seq_quantification", "tumor_rna_seq_quantification", "normal_rna_seq_cgl_workflow_3_0_x", "tumor_rna_seq_cgl_workflow_3_0_x", "normal_rna_seq_cgl_workflow_3_1_x", "tumor_rna_seq_cgl_workflow_3_1_x", "normal_rna_seq_cgl_workflow_3_2_x", "tumor_rna_seq_cgl_workflow_3_2_x", "normal_protect_cgl_workflow_2_3_x", "tumor_protect_cgl_workflow_2_3_x", "normal_cnv_workflow", "tumor_cnv_workflow"],
             "properties": {
                 "normal_sequence": {
                     "type": "array",
@@ -210,6 +211,78 @@
                     }
                 },
                 "tumor_rnaseq_variants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "normal_rna_seq_quantification": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "tumor_rna_seq_quantification": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "normal_rna_seq_cgl_workflow_3_0_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "tumor_rna_seq_cgl_workflow_3_0_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "normal_rna_seq_cgl_workflow_3_1_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "tumor_rna_seq_cgl_workflow_3_1_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "normal_rna_seq_cgl_workflow_3_2_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "tumor_rna_seq_cgl_workflow_3_2_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "normal_protect_cgl_workflow_2_3_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "tumor_protect_cgl_workflow_2_3_x": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "normal_cnv_workflow": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uuid"
+                    }
+                },
+                "tumor_cnv_workflow": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/uuid"
@@ -220,7 +293,7 @@
         "flags": {
             "description": "Indicate whether or not a workflow is complete",
             "type": "object",
-            "required": ["normal_sequence", "tumor_sequence", "normal_alignment", "tumor_alignment", "normal_rnaseq_variants" , "tumor_rnaseq_variants", "normal_germline_variants", "tumor_somatic_variants"],
+            "required": ["normal_sequence", "tumor_sequence", "normal_alignment", "tumor_alignment", "normal_rnaseq_variants" , "tumor_rnaseq_variants", "normal_germline_variants", "tumor_somatic_variants", "normal_rna_seq_quantification" , "tumor_rna_seq_quantification", "normal_rna_seq_cgl_workflow_3_0_x", "tumor_rna_seq_cgl_workflow_3_0_x", "normal_rna_seq_cgl_workflow_3_1_x", "tumor_rna_seq_cgl_workflow_3_1_x", "normal_rna_seq_cgl_workflow_3_2_x", "tumor_rna_seq_cgl_workflow_3_2_x", "normal_protect_cgl_workflow_2_3_x", "tumor_protect_cgl_workflow_2_3_x", "normal_cnv_workflow", "tumor_cnv_workflow"],
             "properties": {
                 "normal_sequence": {
                     "type": "boolean"
@@ -244,6 +317,42 @@
                     "type": "boolean"
                 },
                 "tumor_somatic_variants": {
+                    "type": "boolean"
+                },
+                "normal_rna_seq_quantification": {
+                    "type": "boolean"
+                },
+                "tumor_rna_seq_quantification": {
+                    "type": "boolean"
+                },
+                "normal_rna_seq_cgl_workflow_3_0_x": {
+                    "type": "boolean"
+                },
+                "tumor_rna_seq_cgl_workflow_3_0_x": {
+                    "type": "boolean"
+                },
+                "normal_rna_seq_cgl_workflow_3_1_x": {
+                    "type": "boolean"
+                },
+                "tumor_rna_seq_cgl_workflow_3_1_x": {
+                    "type": "boolean"
+                },
+                "normal_rna_seq_cgl_workflow_3_2_x": {
+                    "type": "boolean"
+                },
+                "tumor_rna_seq_cgl_workflow_3_2_x": {
+                    "type": "boolean"
+                },
+                "normal_protect_cgl_workflow_2_3_x": {
+                    "type": "boolean"
+                },
+                "tumor_protect_cgl_workflow_2_3_x": {
+                    "type": "boolean"
+                },
+                "normal_cnv_workflow": {
+                    "type": "boolean"
+                },
+                "tumor_cnv_workflow": {
                     "type": "boolean"
                 }
             }


### PR DESCRIPTION
Updated the metadata schema for the spinnaker client so files being uploaded have necessary flags.
Let me know if this looks good. 

Note - the line linked below is:

> "pattern": "^[0-9]{1}.[0-9]{1}.[0-9]{1}$"

in the metadata schemas found in dcc-metadata-indexer. Does this matter?

https://github.com/BD2KGenomics/dcc-spinnaker-client/blob/develop/schemas/metadata_schema.json#L15