### PR TITLE
isgc-storage-client upload log fix

### DIFF
--- a/spinnaker.py
+++ b/spinnaker.py
@@ -577,7 +577,8 @@ def perform_upload(manifest, force):
             if 'ERROR' in process_msg:
                 logging.error(process_msg)
             elif process_msg:
-                logging.info(process_msg)
+                sys.stdout.write(process_msg)
+                sys.stdout.flush()
         except:
             continue
     results = process.communicate()

--- a/spinnaker.py
+++ b/spinnaker.py
@@ -573,8 +573,14 @@ def perform_upload(manifest, force):
     fcntl(process.stderr, F_SETFL, flags | os.O_NONBLOCK)
     while process.poll() is None:
         try:
-            sys.stdout.write(os.read(process.stderr.fileno(), 1024))
-            sys.stdout.flush()
+            try:
+                process_msg = os.read(process.stderr.fileno(), 1024).strip()
+                if 'ERROR' in process_msg:
+                    logging.error(process_msg)
+                elif process_msg:
+                    logging.info(process_msg)
+            except:
+                continue
         except:
             continue
     results = process.communicate()

--- a/spinnaker.py
+++ b/spinnaker.py
@@ -573,14 +573,11 @@ def perform_upload(manifest, force):
     fcntl(process.stderr, F_SETFL, flags | os.O_NONBLOCK)
     while process.poll() is None:
         try:
-            try:
-                process_msg = os.read(process.stderr.fileno(), 1024).strip()
-                if 'ERROR' in process_msg:
-                    logging.error(process_msg)
-                elif process_msg:
-                    logging.info(process_msg)
-            except:
-                continue
+            process_msg = os.read(process.stderr.fileno(), 1024).strip()
+            if 'ERROR' in process_msg:
+                logging.error(process_msg)
+            elif process_msg:
+                logging.info(process_msg)
         except:
             continue
     results = process.communicate()

--- a/spinnaker.py
+++ b/spinnaker.py
@@ -573,10 +573,10 @@ def perform_upload(manifest, force):
     fcntl(process.stderr, F_SETFL, flags | os.O_NONBLOCK)
     while process.poll() is None:
         try:
-            process_msg = os.read(process.stderr.fileno(), 1024).strip()
+            process_msg = os.read(process.stderr.fileno(), 1024)
             if 'ERROR' in process_msg:
                 logging.error(process_msg)
-            elif process_msg:
+            elif process_msg.strip():
                 sys.stdout.write(process_msg)
                 sys.stdout.flush()
         except:


### PR DESCRIPTION
isgc-storage-client upload logs are now recorded in spinnaker.log instead of stout
